### PR TITLE
Add Homebrew Cask support for macOS arm64 and introduce packaging wor…

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -43,6 +43,28 @@ jobs:
           set -e
           ./mvnw -ntp -Pdesktop gluonfx:build gluonfx:package
           chmod +x ./target/gluonfx/x86_64-darwin/swaggerific.app
+
+          # Generate .icns from applogo.png and patch Info.plist
+          ICON_PNG=./src/main/resources/applogo.png
+          if [ -f "$ICON_PNG" ]; then
+            echo "Generating AppIcon.icns from $ICON_PNG"
+            TMP_DIR=$(mktemp -d)
+            ICONSET="$TMP_DIR/AppIcon.iconset"
+            mkdir -p "$ICONSET"
+            for size in 16 32 64 128 256 512; do
+              sips -z $size $size     "$ICON_PNG" --out "$ICONSET/icon_${size}x${size}.png" >/dev/null
+              dbl=$((size*2))
+              sips -z $dbl  $dbl      "$ICON_PNG" --out "$ICONSET/icon_${size}x${size}@2x.png" >/dev/null
+            done
+            sips -z 1024 1024 "$ICON_PNG" --out "$ICONSET/icon_512x512@2x.png" >/dev/null || true
+            iconutil -c icns "$ICONSET" -o ./target/gluonfx/x86_64-darwin/swaggerific.app/Contents/Resources/AppIcon.icns
+            rm -rf "$TMP_DIR" || true
+            /usr/libexec/PlistBuddy -c "Set :CFBundleIconFile AppIcon" ./target/gluonfx/x86_64-darwin/swaggerific.app/Contents/Info.plist 2>/dev/null || \
+            /usr/libexec/PlistBuddy -c "Add :CFBundleIconFile string AppIcon" ./target/gluonfx/x86_64-darwin/swaggerific.app/Contents/Info.plist 2>/dev/null || true
+          else
+            echo "WARNING: $ICON_PNG not found; keeping default icon"
+          fi
+
           cp -r ./target/gluonfx/x86_64-darwin/swaggerific.app staging/
           tar -czvf staging/swaggerific_x86_64-darwin.tar.gz -C target/gluonfx/x86_64-darwin swaggerific
           pkgbuild --root ./target/gluonfx/x86_64-darwin/ --identifier io.github.ozkanpakdil.swaggerific --version 0.0.4 --install-location /Applications Swaggerific.pkg

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ replay_pid*
 /.idea/
 /.mvn/
 /dependency-reduced-pom.xml
+
+staging/

--- a/Casks/swaggerific.rb
+++ b/Casks/swaggerific.rb
@@ -1,0 +1,20 @@
+cask "swaggerific" do
+  version :latest
+  sha256 :no_check
+
+  url "https://github.com/ozkanpakdil/swaggerific/releases/download/latest_macos/swaggerific_aarch64-darwin.tar.gz",
+      verified: "github.com/ozkanpakdil/swaggerific"
+  name "Swaggerific"
+  desc "Simple GUI app for working with Swagger/OpenAPI"
+  homepage "https://github.com/ozkanpakdil/swaggerific"
+
+  depends_on arch: :arm64
+
+  app "swaggerific.app"
+
+  caveats <<~EOS
+    This cask targets Apple Silicon (arm64) builds.
+    To install the app into your user Applications folder, run:
+      brew install --cask swaggerific --appdir=~/Applications
+  EOS
+end

--- a/README.md
+++ b/README.md
@@ -10,6 +10,42 @@ You can download the latest version
 from [Github releases ![Download count of latest releases](https://img.shields.io/github/downloads/ozkanpakdil/swaggerific/latest/total.svg)](https://github.com/ozkanpakdil/swaggerific/releases)
 Follow [here](https://bsky.app/profile/swaggerific.bsky.social) for new releases.
 
+## Install via Homebrew (macOS arm64)
+
+Swaggerific is available as a Homebrew Cask for Apple Silicon (arm64) macOS.
+
+1) Tap this repository explicitly by URL:
+
+```bash
+brew tap ozkanpakdil/swaggerific https://github.com/ozkanpakdil/swaggerific
+```
+
+2) Install into your user Applications folder:
+
+```bash
+brew install --cask swaggerific --appdir=~/Applications
+```
+
+- Update to the latest build later:
+
+```bash
+brew upgrade --cask swaggerific
+```
+
+- Uninstall:
+
+```bash
+brew uninstall --cask swaggerific
+```
+
+Notes:
+- This cask targets Apple Silicon (arm64) builds only.
+- It pulls the latest prebuilt app bundle from the `latest_macos` GitHub release.
+
+## Packaging artifacts
+
+The macOS packaging script `build-macos-arm64.sh` places generated artifacts under the `staging/` directory (tar.gz, .pkg, and installer .pkg). The `staging/` folder is ignored by Git.
+
 ## Requirements
 
 - Java Development Kit (JDK) 17 or higher

--- a/build-macos-arm64.sh
+++ b/build-macos-arm64.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Package builder for macOS Apple Silicon (arm64 / aarch64)
+# This script packages the already-built Gluon native image into:
+# - a tar.gz archive
+# - a .pkg and a product .pkg installer
+#
+# Requirements:
+# - The native image should already be built at target/gluonfx/aarch64-darwin/swaggerific.app
+# - pkgbuild and productbuild must be available (macOS only)
+
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET_DIR="$ROOT_DIR/target/gluonfx/aarch64-darwin"
+APP_NAME="swaggerific.app"
+APP_PATH="$TARGET_DIR/$APP_NAME"
+STAGING_DIR="$ROOT_DIR/staging"
+IDENTIFIER="io.github.ozkanpakdil.swaggerific"
+APP_ICON_PNG="$ROOT_DIR/src/main/resources/applogo.png"
+
+# Obtain project version from Maven (falls back to 0.0.0 if unavailable)
+VERSION="$(./mvnw -q -DforceStdout help:evaluate -Dexpression=project.version 2>/dev/null || echo 0.0.0)"
+if [[ -z "$VERSION" || "$VERSION" == *"["* ]]; then
+  VERSION="0.0.0"
+fi
+
+echo "Using version: $VERSION"
+
+if [[ ! -d "$TARGET_DIR" ]]; then
+  echo "Error: Expected target directory not found: $TARGET_DIR" >&2
+  echo "Please build the native image first, e.g.: ./mvnw -ntp -Pdesktop gluonfx:build gluonfx:package" >&2
+  exit 1
+fi
+
+if [[ ! -d "$APP_PATH" ]]; then
+  echo "Error: Expected app bundle not found: $APP_PATH" >&2
+  echo "Please build the native image first, e.g.: ./mvnw -ntp -Pdesktop gluonfx:build gluonfx:package" >&2
+  exit 1
+fi
+
+mkdir -p "$STAGING_DIR"
+
+# Ensure the .app is executable (main binary inside .app will already be executable, but keep parity with CI)
+chmod -R +x "$APP_PATH" || true
+
+echo "Copying $APP_NAME to staging..."
+rsync -a "$APP_PATH" "$STAGING_DIR/"
+
+# Prepare icon: convert applogo.png -> .icns and patch Info.plist in the staged app
+STAGED_APP="$STAGING_DIR/$APP_NAME"
+ICNS_NAME="AppIcon.icns"
+TMP_ICONSET_DIR="$(mktemp -d)"/AppIcon.iconset
+
+if [[ -f "$APP_ICON_PNG" ]]; then
+  echo "Generating macOS .icns from $APP_ICON_PNG ..."
+  mkdir -p "$TMP_ICONSET_DIR"
+  # Generate required icon sizes
+  for size in 16 32 64 128 256 512; do
+    sips -z $size $size     "$APP_ICON_PNG" --out "$TMP_ICONSET_DIR/icon_${size}x${size}.png" >/dev/null
+    dbl=$((size*2))
+    sips -z $dbl  $dbl      "$APP_ICON_PNG" --out "$TMP_ICONSET_DIR/icon_${size}x${size}@2x.png" >/dev/null
+  done
+  # 1024x1024 (optional but good for retina)
+  sips -z 1024 1024 "$APP_ICON_PNG" --out "$TMP_ICONSET_DIR/icon_512x512@2x.png" >/dev/null || true
+  iconutil -c icns "$TMP_ICONSET_DIR" -o "$STAGED_APP/Contents/Resources/$ICNS_NAME"
+  rm -rf "$(dirname "$TMP_ICONSET_DIR")" || true
+
+  PLIST="$STAGED_APP/Contents/Info.plist"
+  if [[ -f "$PLIST" ]]; then
+    echo "Patching CFBundleIconFile in Info.plist ..."
+    /usr/libexec/PlistBuddy -c "Set :CFBundleIconFile AppIcon" "$PLIST" 2>/dev/null || \
+    /usr/libexec/PlistBuddy -c "Add :CFBundleIconFile string AppIcon" "$PLIST" 2>/dev/null || true
+  fi
+else
+  echo "Warning: App icon PNG not found at $APP_ICON_PNG. Using existing icon if any." >&2
+fi
+
+ARCHIVE_NAME="swaggerific_aarch64-darwin.tar.gz"
+echo "Creating archive $ARCHIVE_NAME ..."
+tar -czvf "$STAGING_DIR/$ARCHIVE_NAME" -C "$TARGET_DIR" "swaggerific.app"
+
+PKG_NAME="Swaggerific.pkg"
+INSTALLER_NAME="SwaggerificInstaller.pkg"
+
+echo "Building pkg ($PKG_NAME) ..."
+pkgbuild \
+  --root "$TARGET_DIR/" \
+  --identifier "$IDENTIFIER" \
+  --version "$VERSION" \
+  --install-location "/Applications" \
+  "$PKG_NAME"
+
+echo "Building product installer ($INSTALLER_NAME) ..."
+productbuild --package "$PKG_NAME" "$INSTALLER_NAME"
+
+echo "Moving installer(s) to staging ..."
+mv -f "$PKG_NAME" "$STAGING_DIR/"
+mv -f "$INSTALLER_NAME" "$STAGING_DIR/"
+
+echo "Done. Artifacts:"
+echo " - $STAGING_DIR/$ARCHIVE_NAME"
+echo " - $STAGING_DIR/$PKG_NAME"
+echo " - $STAGING_DIR/$INSTALLER_NAME"


### PR DESCRIPTION
…kflow

- Introduce a Homebrew Cask (`swaggerific.rb`) for macOS Apple Silicon (arm64) support.
- Add a `build-macos-arm64.sh` script for packaging `.app`, `.tar.gz`, `.pkg`, and `.product.pkg` artifacts.
- Update GitHub workflow to patch icons and bundle resources for arm64 packages.
- Expand README with Homebrew installation instructions and packaging details.
- Ignore the staging directory in `.gitignore`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Homebrew Cask for easy installation on macOS arm64 devices

* **Documentation**
  * Installation instructions for macOS via Homebrew with upgrade/uninstall options
  * Overview of macOS packaging artifacts and storage

* **Chores**
  * Enhanced macOS build workflow with automated icon generation and installer packaging

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->